### PR TITLE
Update runtime to 6.9

### DIFF
--- a/org.kde.kget.json
+++ b/org.kde.kget.json
@@ -37,6 +37,7 @@
         },
         {
             "name": "gpgme",
+            "builddir": true,
             "sources": [
                 {
                     "type": "archive",
@@ -49,25 +50,25 @@
                         "url-template": "https://gnupg.org/ftp/gcrypt/gpgme/gpgme-$version.tar.bz2"
                     }
                 }
-            ],
-            "cleanup": [
-                "/lib/libgpgme*.la"
             ]
         },
         {
             "name": "gpgmepp",
             "buildsystem": "cmake-ninja",
-            "builddir": true,
+            "config-opts": [
+                "-DBUILD_TESTING=OFF",
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.gnupg.org/ftp/gcrypt/gpgmepp/gpgmepp-2.0.0.tar.xz",
+                    "url": "https://gnupg.org/ftp/gcrypt/gpgmepp/gpgmepp-2.0.0.tar.xz",
                     "sha256": "d4796049c06708a26f3096f748ef095347e1a3c1e570561701fe952c3f565382",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 378536,
                         "stable-only": true,
-                        "url-template": "https://www.gnupg.org/ftp/gcrypt/gpgmepp/gpgmepp-$version.tar.xz"
+                        "url-template": "https://gnupg.org/ftp/gcrypt/gpgmepp/gpgmepp-$version.tar.bz2"
                     }
                 }
             ]
@@ -75,10 +76,9 @@
         {
             "name": "qgpgme",
             "buildsystem": "cmake-ninja",
-            "builddir": true,
             "config-opts": [
-                "-DBUILD_WITH_QT5=OFF",
-                "-DBUILD_WITH_QT6=ON"
+                "-DBUILD_TESTING=OFF",
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
             ],
             "sources": [
                 {
@@ -89,12 +89,9 @@
                         "type": "anitya",
                         "project-id": 378538,
                         "stable-only": true,
-                        "url-template": "https://gnupg.org/ftp/gcrypt/qgpgme/qgpgme-$version.tar.xz"
+                        "url-template": "https://gnupg.org/ftp/gcrypt/qgpgme/qgpgme-$version.tar.bz2"
                     }
                 }
-            ],
-            "cleanup": [
-                "/lib/libqgpgme.la"
             ]
         },
         {

--- a/org.kde.kget.json
+++ b/org.kde.kget.json
@@ -50,6 +50,10 @@
                         "url-template": "https://gnupg.org/ftp/gcrypt/gpgme/gpgme-$version.tar.bz2"
                     }
                 }
+            ],
+            "cleanup": [
+                "/lib/libgpgme*.la",
+                "/lib/libqgpgme.la"
             ]
         },
         {

--- a/org.kde.kget.json
+++ b/org.kde.kget.json
@@ -41,55 +41,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gnupg.org/ftp/gcrypt/gpgme/gpgme-2.0.0.tar.bz2",
-                    "sha256": "ddf161d3c41ff6a3fcbaf4be6c6e305ca4ef1cc3f1ecdfce0c8c2a167c0cc36d",
+                    "url": "https://gnupg.org/ftp/gcrypt/gpgme/gpgme-1.24.3.tar.bz2",
+                    "sha256": "bfc17f5bd1b178c8649fdd918956d277080f33df006a2dc40acdecdce68c50dd",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 1239,
                         "stable-only": true,
                         "url-template": "https://gnupg.org/ftp/gcrypt/gpgme/gpgme-$version.tar.bz2"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "gpgmepp",
-            "buildsystem": "cmake-ninja",
-            "config-opts": [
-                "-DBUILD_TESTING=OFF",
-                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://gnupg.org/ftp/gcrypt/gpgmepp/gpgmepp-2.0.0.tar.xz",
-                    "sha256": "d4796049c06708a26f3096f748ef095347e1a3c1e570561701fe952c3f565382",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 378536,
-                        "stable-only": true,
-                        "url-template": "https://gnupg.org/ftp/gcrypt/gpgmepp/gpgmepp-$version.tar.bz2"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "qgpgme",
-            "buildsystem": "cmake-ninja",
-            "config-opts": [
-                "-DBUILD_TESTING=OFF",
-                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://gnupg.org/ftp/gcrypt/qgpgme/qgpgme-2.0.0.tar.xz",
-                    "sha256": "15645b2475cca6118eb2ed331b3a8d9442c9d4019c3846ba3f6d25321b4a61ad",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 378538,
-                        "stable-only": true,
-                        "url-template": "https://gnupg.org/ftp/gcrypt/qgpgme/qgpgme-$version.tar.bz2"
                     }
                 }
             ]

--- a/org.kde.kget.json
+++ b/org.kde.kget.json
@@ -1,7 +1,7 @@
 {
     "id": "org.kde.kget",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.8",
+    "runtime-version": "6.9",
     "sdk": "org.kde.Sdk",
     "command": "kget",
     "finish-args": [
@@ -37,12 +37,11 @@
         },
         {
             "name": "gpgme",
-            "builddir": true,
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gnupg.org/ftp/gcrypt/gpgme/gpgme-1.24.3.tar.bz2",
-                    "sha256": "bfc17f5bd1b178c8649fdd918956d277080f33df006a2dc40acdecdce68c50dd",
+                    "url": "https://gnupg.org/ftp/gcrypt/gpgme/gpgme-2.0.0.tar.bz2",
+                    "sha256": "ddf161d3c41ff6a3fcbaf4be6c6e305ca4ef1cc3f1ecdfce0c8c2a167c0cc36d",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 1239,
@@ -52,7 +51,49 @@
                 }
             ],
             "cleanup": [
-                "/lib/libgpgme*.la",
+                "/lib/libgpgme*.la"
+            ]
+        },
+        {
+            "name": "gpgmepp",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.gnupg.org/ftp/gcrypt/gpgmepp/gpgmepp-2.0.0.tar.xz",
+                    "sha256": "d4796049c06708a26f3096f748ef095347e1a3c1e570561701fe952c3f565382",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 378536,
+                        "stable-only": true,
+                        "url-template": "https://www.gnupg.org/ftp/gcrypt/gpgmepp/gpgmepp-$version.tar.xz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "qgpgme",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DBUILD_WITH_QT5=OFF",
+                "-DBUILD_WITH_QT6=ON"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://gnupg.org/ftp/gcrypt/qgpgme/qgpgme-2.0.0.tar.xz",
+                    "sha256": "15645b2475cca6118eb2ed331b3a8d9442c9d4019c3846ba3f6d25321b4a61ad",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 378538,
+                        "stable-only": true,
+                        "url-template": "https://gnupg.org/ftp/gcrypt/qgpgme/qgpgme-$version.tar.xz"
+                    }
+                }
+            ],
+            "cleanup": [
                 "/lib/libqgpgme.la"
             ]
         },


### PR DESCRIPTION
~~`gpgmepp` and `qgpgme` are not bundled with `gpgme` anymore~~